### PR TITLE
 Larger block size for ip pool

### DIFF
--- a/infrastructure/calico-cni.yaml
+++ b/infrastructure/calico-cni.yaml
@@ -4568,6 +4568,8 @@ spec:
             # no effect. This should fall within `--cluster-cidr`.
             - name: CALICO_IPV4POOL_CIDR
               value: "100.64.0.0/16"
+            - name: CALICO_IPV4POOL_BLOCK_SIZE
+              value: "24"
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"
             # Disable file logging so `kubectl logs` works.


### PR DESCRIPTION
If we increase block size from `/26` to `/24` the tests pass successfully without timeouts:
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/903531/212283337-8634de2e-3863-4d15-8fb9-127c76285cd5.png">
