### PR TITLE
Dedicated ip pool for jobs

### DIFF
--- a/infrastructure/calico-cni.yaml
+++ b/infrastructure/calico-cni.yaml
@@ -4750,3 +4750,18 @@ spec:
                 - /usr/bin/check-status
                 - -r
             periodSeconds: 10
+---
+apiVersion: crd.projectcalico.org/v1
+kind: IPPool
+metadata:
+  name: job-queue-jobs-ipv4-ippool
+spec:
+  allowedUses:
+    - Workload
+    - Tunnel
+  blockSize: 24
+  cidr: 100.65.0.0/16
+  ipipMode: Never
+  natOutgoing: true
+  nodeSelector: "nodepool in { 'job-queue-jobs', 'job-queue-jobs-large', 'job-queue-jobs-short-run-time', 'job-queue-jobs-long-run-time' }"
+  vxlanMode: CrossSubnet

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -73,8 +73,20 @@ module "eks" {
       max_size     = 1
       desired_size = 1
 
-      instance_type                          = "r6a.4xlarge"
+      instance_type                          = "t3a.large"
       update_launch_template_default_version = true
+
+    }
+
+    jobs = {
+      name         = "jobs"
+      max_size     = 1
+      desired_size = 1
+
+      instance_type                          = "r5a.4xlarge"
+      update_launch_template_default_version = true
+
+      bootstrap_extra_args = "--kubelet-extra-args '--node-labels=nodepool=job-queue-jobs --register-with-taints=app=job-queue-jobs:NoSchedule'"
 
     }
   }

--- a/scripts/generate-pods.sh
+++ b/scripts/generate-pods.sh
@@ -57,7 +57,7 @@ spec:
   - effect: NoSchedule
     key: app
     operator: Equal
-    value: job-queue-jobs-short-run-time
+    value: job-queue-jobs
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists
@@ -66,6 +66,8 @@ spec:
     key: node.kubernetes.io/unreachable
     operator: Exists
     tolerationSeconds: 300
+  nodeSelector:
+    nodepool: job-queue-jobs
   volumes:
   - name: test-scripts-volume
     configMap:


### PR DESCRIPTION
- Dedicated IP pool with /24 block size for job nodepools.
- It still assigns IPs from default. To make it work `default-ipv4-ippool` nodeSelector have to be patched to `nodepool not in { 'job-queue-jobs', 'job-queue-jobs-large', 'job-queue-jobs-short-run-time', 'job-queue-jobs-long-run-time' }`